### PR TITLE
Output format python is now possible to set and use.

### DIFF
--- a/check_mk_web_api/__init__.py
+++ b/check_mk_web_api/__init__.py
@@ -3,6 +3,7 @@ import json
 import os.path
 import re
 import ast
+
 from six.moves import urllib
 
 from check_mk_web_api.exception import CheckMkWebApiResponseException, CheckMkWebApiException, CheckMkWebApiAuthenticationException
@@ -141,16 +142,14 @@ class WebApi:
         if body.startswith('Authentication error:'):
             raise CheckMkWebApiAuthenticationException(body)
 
-        if "output_format" in query_params and query_params["output_format"] == "python":
+        if 'output_format' in query_params and query_params['output_format'] == 'python':
             body_dict = ast.literal_eval(body)
-            result = body_dict['result']
-            if body_dict['result_code'] == 0:
-                return result
         else:
-            body_json = json.loads(body)
-            result = body_json['result']
-            if body_json['result_code'] == 0:
-                return result
+            body_dict = json.loads(body)
+
+        result = body_dict['result']
+        if body_dict['result_code'] == 0:
+            return result
 
         raise CheckMkWebApiException(result)
 

--- a/check_mk_web_api/__init__.py
+++ b/check_mk_web_api/__init__.py
@@ -2,6 +2,7 @@ import enum
 import json
 import os.path
 import re
+import ast
 from six.moves import urllib
 
 from check_mk_web_api.exception import CheckMkWebApiResponseException, CheckMkWebApiException, CheckMkWebApiAuthenticationException
@@ -140,11 +141,16 @@ class WebApi:
         if body.startswith('Authentication error:'):
             raise CheckMkWebApiAuthenticationException(body)
 
-        body_json = json.loads(body)
-        result = body_json['result']
-
-        if body_json['result_code'] == 0:
-            return result
+        if "output_format" in query_params and query_params["output_format"] == "python":
+            body_dict = ast.literal_eval(body)
+            result = body_dict['result']
+            if body_dict['result_code'] == 0:
+                return result
+        else:
+            body_json = json.loads(body)
+            result = body_json['result']
+            if body_json['result_code'] == 0:
+                return result
 
         raise CheckMkWebApiException(result)
 


### PR DESCRIPTION
Result is now parsed according to "output_format" settings in query
parameters. For some outputs it is necessary to set the format to
"python". As an example "rulesets" need the setting for the output
format.

Example query looks like this
api.make_request('get_ruleset',query_params={"output_format":"python"},  data={"ruleset_name":"host_contactgroups"})