### PR TITLE
 invalid pattern for matching service discovery stats

### DIFF
--- a/check_mk_web_api/__init__.py
+++ b/check_mk_web_api/__init__.py
@@ -46,8 +46,8 @@ class WebApi:
 
     __DISCOVERY_REGEX = {
         'added': [re.compile(r'.*Added (\d+),.*')],
-        'removed': [re.compile(r'.*([Rr])emoved (\d+),.*')],
-        'kept': [re.compile(r'.*([Kk])ept (\d+),.*')],
+        'removed': [re.compile(r'.*[Rr]emoved (\d+),.*')],
+        'kept': [re.compile(r'.*[Kk]ept (\d+),.*')],
         'new_count': [re.compile(r'.*New Count (\d+)$'), re.compile(r'.*(\d+) new.*')]  # output changed in 1.6 so we have to try multiple patterns
     }
 


### PR DESCRIPTION
Thanks for all the good work, this module saved me a lot of time. I found an issue  in the result of the discover_services introduced in a previous change.

Currently it returns {'added': '0', 'removed': 'R', 'kept': 'K', 'new_count': '905'}
While it should return {'added': '0', 'removed': '0', 'kept': '905', 'new_count': '905'}

The solution is to change the regex __DISCOVERY_REGEX patterns to return only one group