### PR TITLE
remove import urllib.parse to stay compatible with python2

### DIFF
--- a/check_mk_web_api/__init__.py
+++ b/check_mk_web_api/__init__.py
@@ -3,7 +3,6 @@ import json
 import os.path
 import re
 import ast
-import urllib.parse
 
 from six.moves import urllib
 


### PR DESCRIPTION
The "import urllib.parse" was introduced with commit 50bba2a to fix
requests containing an '&' character. But the class WebApi already
used urllib.parse through the use of "from six.moves import urllib".
The introduction of "import urllib.parse" made the module incompatible
with Python2.